### PR TITLE
Added nullcheck to AspNetCoreMvcMetricCollectorActionFilter

### DIFF
--- a/src/Common.props
+++ b/src/Common.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <Authors>Renato Golia</Authors>
-        <Version>1.1.1</Version>
+        <Version>1.1.2</Version>
         <Product>Kralizek.AspNetCore.Metrics</Product>
         <PackageProjectUrl>https://github.com/Kralizek/AspNetCore.Metrics</PackageProjectUrl>
         <PackageLicenseUrl>https://raw.githubusercontent.com/Kralizek/AspNetCore.Metrics/master/LICENSE</PackageLicenseUrl>

--- a/src/Kralizek.AspNetCore.Metrics.Collectors.Mvc/Filters/AspNetCoreMvcMetricCollectorActionFilter.cs
+++ b/src/Kralizek.AspNetCore.Metrics.Collectors.Mvc/Filters/AspNetCoreMvcMetricCollectorActionFilter.cs
@@ -17,12 +17,23 @@ namespace Kralizek.AspNetCore.Metrics.Filters
             
             var controllerNamespace = context.Controller?.GetType().Namespace;
 
-            var dimensions = new Dictionary<IMetricDimension, object>(MetricDimensionEqualityComparer.Default)
+            var dimensions = new Dictionary<IMetricDimension, object>(MetricDimensionEqualityComparer.Default);
+
+            if (!string.IsNullOrEmpty(controllerName))
             {
-                [AspNetCoreMvcMetricDimensions.ControllerName] = controllerName,
-                [AspNetCoreMvcMetricDimensions.ActionName] = actionName,
-                [AspNetCoreMvcMetricDimensions.Action] = $"{controllerName}.{actionName} ({controllerNamespace})"
-            };
+                dimensions.Add(AspNetCoreMvcMetricDimensions.ControllerName, controllerName);
+            }
+
+            if (!string.IsNullOrEmpty(actionName))
+            {
+                dimensions.Add(AspNetCoreMvcMetricDimensions.ActionName, actionName);
+            }
+
+            if (!string.IsNullOrEmpty(controllerName) && !string.IsNullOrEmpty(actionName) &&
+                !string.IsNullOrEmpty(controllerNamespace))
+            {
+                dimensions.Add(AspNetCoreMvcMetricDimensions.Action, $"{controllerName}.{actionName} ({controllerNamespace})");
+            }
 
             context.HttpContext.Items.Add(AspNetCoreMvcMetricCollector.HttpContextDimensionsKey, dimensions);
 


### PR DESCRIPTION
- Added nullcheck to AspNetCoreMvcMetricCollectorActionFilter for ControllerName, ActionName and Action dimensions to prevent logging of metrics with no dimensions
- Changed the version to 1.1.2